### PR TITLE
add gswm and gswd command

### DIFF
--- a/aliases.md
+++ b/aliases.md
@@ -118,6 +118,8 @@
 | `gsts` | `git stash show --text $args` |
 | `gsu`  | `git submodule update $args` |
 | `gsw`  | `git switch $args` |
+| `gswm` | Script to switch to main branch. |
+| `gswd` | Script to switch to develop branch. |
 | `gts`  | `git tag -s $args` |
 | `gunignore`| `git update-index --no-assume-unchanged $args` |
 | `gunwip`| Script to remove a WIP commit. |

--- a/src/aliases.ps1
+++ b/src/aliases.ps1
@@ -400,6 +400,14 @@ function gsu {
 function gsw {
 	git switch $args
 }
+function gswm {
+	$MainBranch = Get-Git-MainBranch
+	git switch $MainBranch $args
+}
+function gswm {
+	$DevelopBranch = Get-Git-DevelopBranch
+	git switch $DevelopBranch $args
+}
 function gts {
 	git tag -s $args
 }

--- a/src/git-aliases.psm1
+++ b/src/git-aliases.psm1
@@ -123,6 +123,8 @@ $FunctionsToExport = @(
 	'gsts',
 	'gsu',
 	'gsw',
+	'gswm',
+	'gswd',
 	'gts',
 	'gunignore',
 	'gunwip',

--- a/src/utils.ps1
+++ b/src/utils.ps1
@@ -32,6 +32,24 @@ function Get-Git-MainBranch {
 	return 'master'
 }
 
+function Get-Git-DevelopBranch {
+    git rev-parse --git-dir *> $null
+    if ($LASTEXITCODE -ne 0) {
+        return
+    }
+
+    $branches = @("dev", "devel", "develop", "development")
+
+    foreach ($branch in $branches) {
+        & git show-ref -q --verify "refs/heads/$branch" *> $null
+        if ($LASTEXITCODE -eq 0) {
+            return $branch
+        }
+    }
+
+    return "develop"
+}
+
 # Don't add `Remove-Alias` on PowerShell >= 6.
 # PowerShell >= 6 already has built-in `Remove-Alias`.
 # Let use built-in `Remove-Alias` on PowerShell >= 6.


### PR DESCRIPTION
This pull request introduces new git aliases and functions to streamline branch switching in the repository. The key changes include adding new aliases for switching to the main and develop branches, and implementing corresponding functions in the PowerShell script.

New aliases and functions:

* [`aliases.md`](diffhunk://#diff-df2a57cb9b6dce12343fec4f848f468b77b30b83cd804be95b01c8d4df21e91eR121-R122): Added new aliases `gswm` and `gswd` for switching to the main and develop branches, respectively.
* [`src/aliases.ps1`](diffhunk://#diff-ad42a217095f5a9cc3960e238d16bc9b5cf3ab238b9a6bcd28bf2c295cdde660R403-R410): Added functions `gswm` and `gswd` to switch to the main and develop branches using the new aliases.
* [`src/git-aliases.psm1`](diffhunk://#diff-73e2df51951e77bb47dbe3987c30939d239535a8cd8439b7b58391044a50c3f6R126-R127): Updated the export list to include the new functions `gswm` and `gswd`.

Utility function enhancement:

* [`src/utils.ps1`](diffhunk://#diff-d81912b5782de1629c419b893aee92b2187f07c898d82d61c61d4c16a7821a4fR35-R52): Added a new function `Get-Git-DevelopBranch` to determine the develop branch name from a list of common names.